### PR TITLE
Fix electron runner on Windows

### DIFF
--- a/packages/electron/src/TestRunner.js
+++ b/packages/electron/src/TestRunner.js
@@ -65,7 +65,7 @@ export default class TestRunner {
           const injectedCodePath = require.resolve(
             './electron_process_injected_code.js',
           );
-          return spawn(ELECTRON_BIN, [injectedCodePath], {
+          return spawn('node', [ELECTRON_BIN, injectedCodePath], {
             stdio: [
               'inherit',
               // redirect child process' stdout to parent process stderr, so it


### PR DESCRIPTION
On Windows, we cannot run the electron binary since it is using a shebang, and those aren't supported 😞 

We could use something like [`cross-spawn`](https://www.npmjs.com/package/cross-spawn) or we can use [`node` directly](https://stackoverflow.com/a/43420003) to execute the script.