### PR TITLE
Use root project's Electron so native modules resolve correctly

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -7,6 +7,7 @@
     "homepage": "https://github.com/facebook-atom/jest-electron-runner",
     "repository": "https://github.com/facebook-atom/jest-electron-runner",
     "dependencies": {
+        "app-root-path": "^2.0.1",
         "@jest-runner/core": "^0.0.14",
         "@jest-runner/rpc": "^0.0.14",
         "electron": "^2.0.8",

--- a/packages/electron/src/TestRunner.js
+++ b/packages/electron/src/TestRunner.js
@@ -26,7 +26,17 @@ import type {ServerID} from '../../core/src/utils';
 // the whole thing in watch mode every time.
 let jestWorkerRPCProcess;
 
-const ELECTRON_BIN = path.resolve(require.resolve('electron'), '..', 'cli.js');
+// Prefer the Electron installed in the project's root directory. This allows
+// the user's Electron version to be used when resolving native native module
+// paths. Example: (notice v3.0 vs. v2.0)
+//   node_modules/sqlite3/lib/binding/electron-v3.0-darwin-x64/node_sqlite3.node
+//   vs.
+//   node_modules/sqlite3/lib/binding/electron-v2.0-darwin-x64/node_sqlite3.node
+// For development, the Electron version in jest-electron-runner's package.json
+// will be used.
+// https://github.com/facebook-atom/jest-electron-runner/issues/6
+const appRoot = require('app-root-path');
+const ELECTRON_BIN = path.join(appRoot.path, 'node_modules', 'electron', 'cli.js');
 
 const once = fn => {
   let hasBeenCalled = false;


### PR DESCRIPTION
Prefer the Electron installed in the project's root directory. This allows
the user's Electron version to be used when resolving native native module
paths. Example: (notice v3.0 vs. v2.0)
  node_modules/sqlite3/lib/binding/electron-v3.0-darwin-x64/node_sqlite3.node
  vs.
  node_modules/sqlite3/lib/binding/electron-v2.0-darwin-x64/node_sqlite3.node
For development, the Electron version in jest-electron-runner's package.json
will be used.
https://github.com/facebook-atom/jest-electron-runner/issues/6