### PR TITLE
Ensure only one listener is registered locally per channel (#14)

### DIFF
--- a/packages/electron/src/TestRunner.js
+++ b/packages/electron/src/TestRunner.js
@@ -55,11 +55,9 @@ export default class TestRunner {
   _globalConfig: GlobalConfig;
   _serverID: ServerID;
   _ipcServerPromise: Promise<IPCServer>;
-  _processEventRegistered: Object;
 
   constructor(globalConfig: GlobalConfig) {
     this._globalConfig = globalConfig;
-    this._processEventRegistered = {};
   }
 
   async runTests(


### PR DESCRIPTION
When a test fails, the test-runner module does not clear the registered listeners, leading to additional ones being added and causing a memory leak.

This pull request stores a hash of locally registered listeners and ensures that it gets registered only once.