### PR TITLE
disable react devtools check 

### DIFF
--- a/packages/electron/src/browser_window_injected_code.js
+++ b/packages/electron/src/browser_window_injected_code.js
@@ -11,6 +11,10 @@
 // and tries to write them every time it runs
 window.ELECTRON_DISABLE_SECURITY_WARNINGS = true;
 
+// react devtools only checks for the presence of a production environment
+// in order to suggest downloading it, which means it logs a msg in a test environment
+window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {isDisabled: true};
+
 import type {IPCTestData} from '../types';
 
 import {buildFailureTestResult} from '@jest-runner/core/utils';


### PR DESCRIPTION
React devtools only checks for the presence of a production environment or useragent in order to suggest downloading it, which means it logs a msg in a test environment. 

This PR disables this check within a browser environment.

fixes #20