### PR TITLE
rpc: Bump jscodeshift@0.6.3

### DIFF
--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
         "@jest-runner/core": "^1.0.2",
         "glob": "^7.1.3",
-        "jscodeshift": "^0.5.1",
+        "jscodeshift": "^0.6.3",
         "prettier": "^1.14.2",
         "yargs": "^12.0.1"
     },


### PR DESCRIPTION
Bumps [jscodeshift](https://github.com/facebook/jscodeshift) to 0.6.3, fixing a ReDoS [vulnerability](https://app.snyk.io/test/npm/@jest-runner/rpc/1.0.2) in `braces` (an indirect dependency)