### PR TITLE
Add node-ipc as a dependency of @jest-runner/rpc

### DIFF
--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -10,6 +10,7 @@
         "@jest-runner/core": "^1.0.2",
         "glob": "^7.1.3",
         "jscodeshift": "^0.6.3",
+        "node-ipc": "^9.1.1",
         "prettier": "^1.14.2",
         "yargs": "^12.0.1"
     },


### PR DESCRIPTION
In strict package managers such as pnpm or yarn pnp, node cannot resolve
'node-ipc' from @jest-runner/rpc, e.g. in RPCConnection.js:

    import {IPC} from 'node-ipc';

Adding node-ipc as a direct dependency of @jest-runner/rpc fixes this.