### PR TITLE
Sets consistant render scale

### DIFF
--- a/packages/electron/src/electron_process_injected_code.js
+++ b/packages/electron/src/electron_process_injected_code.js
@@ -26,6 +26,11 @@ app.on('ready', async () => {
   // eslint-disable-next-line no-unused-vars
   const mainWindow = new BrowserWindow({show: false});
 
+  // for testing purposes, it is probably a good idea to keep everything at
+  // the same scale so that renders do not vary from device to device.
+  app.commandLine.appendSwitch('high-dpi-support', 1);
+  app.commandLine.appendSwitch('force-device-scale-factor', 1);
+
   if (isMain) {
     // we spin up an electron process for each test on the main process
     // which pops up an icon for each on macOs. Hiding them is less intrusive


### PR DESCRIPTION
One and only change for this pull request. Our team here was running into an issue while using this library with image snapshot tests. 

Essentially the `render` function will render the components at different sizes if you have the scale set differently from device to device, causing image snapshot tests to fail depending on what device you run the tests on. 

This change forces the electron environment to keep a consistent scale factor, regardless of what scale the os is set to.

Thank you for your time. Please let me know if you have any questions, concerns, or comments