### PR TITLE
Add uuid as a dependency of @jest-runner/rpc

### DIFF
--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -12,6 +12,7 @@
         "jscodeshift": "^0.6.3",
         "node-ipc": "^9.1.1",
         "prettier": "^1.14.2",
+        "uuid": "^3.3.2",
         "yargs": "^12.0.1"
     },
     "bin": {


### PR DESCRIPTION
For the same reason as https://github.com/facebook-atom/jest-electron-runner/pull/32