### PR TITLE
Add throat as a dependency of @jest-runner/electron

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -14,6 +14,7 @@
         "jest-mock": "^24.0.0",
         "jest-runner": "^24.0.0",
         "jest-runtime": "^24.0.0",
-        "jest-util": "^24.0.0"
+        "jest-util": "^24.0.0",
+        "throat": "^4.1.0"
     }
 }


### PR DESCRIPTION
For the same reason as https://github.com/facebook-atom/jest-electron-runner/pull/32