### PR TITLE
electron: Make electron a peerDependency

### DIFF
--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -9,12 +9,14 @@
     "dependencies": {
         "@jest-runner/core": "^1.0.2",
         "@jest-runner/rpc": "^1.1.0",
-        "electron": "^2.0.8",
         "jest-haste-map": "^24.0.0",
         "jest-mock": "^24.0.0",
         "jest-runner": "^24.0.0",
         "jest-runtime": "^24.0.0",
         "jest-util": "^24.0.0",
         "throat": "^4.1.0"
+    },
+    "peerDependencies": {
+        "electron": "*"
     }
 }

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -18,5 +18,8 @@
     },
     "peerDependencies": {
         "electron": "*"
+    },
+    "devDependencies": {
+        "electron": "^2.0.8"
     }
 }


### PR DESCRIPTION
`electron` is listed as a dependency of `@jest-runner/electron`. If a user is using another version of `electron`, they will end up with an unnecessary additional version of `electron` in their `node_modules`. This PR moves it to a `peerDependency` so that users know that they need `electron`, but not a specific version.

Fixes #31 
