### PR TITLE
Electron 5 compatibility

### DIFF
--- a/packages/electron/src/rpc/JestWorkerRPC.js
+++ b/packages/electron/src/rpc/JestWorkerRPC.js
@@ -44,7 +44,10 @@ const _runInNode = async (testData: IPCTestData): Promise<TestResult> => {
 const _runInBrowserWindow = (testData: IPCTestData): Promise<TestResult> => {
   return new Promise(resolve => {
     const workerID = makeUniqWorkerId();
-    const win = new BrowserWindow({show: false});
+    const win = new BrowserWindow({
+      show: false,
+      webPreferences: { nodeIntegration: true }
+    });
 
     win.loadURL(`file://${require.resolve('../index.html')}`);
     win.webContents.on('did-finish-load', () => {


### PR DESCRIPTION
The nodeIntegration flag in BrowserWindow webPreferences had a
default value of true in earlier versions of Electron. The default
value has changed to false in Electron 5. A value of true (i.e.
the presence of the Node environment) is necessary for the test
runner to run as it is currently written.