### PR TITLE
rpc: Bump yargs to 15.3.1

### DIFF
--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -13,7 +13,7 @@
         "node-ipc": "^9.1.1",
         "prettier": "^1.14.2",
         "uuid": "^3.3.2",
-        "yargs": "^12.0.1"
+        "yargs": "^15.3.1"
     },
     "bin": {
         "jest-runner-rpc-generate": "./bin/cli.js"


### PR DESCRIPTION
`yargs-parser@11.1.1` (from `yargs@12.0.5`) is [vulnerable to prototype pollution](https://app.snyk.io/vuln/SNYK-JS-YARGSPARSER-560381). This PR bumps `yargs` to 15.3.1 which resolves audit pipelines that may be reporting a [vulnerability](https://app.snyk.io/test/npm/@jest-runner/rpc) in `@jest-runner/rpc`. This could be a breaking change since it drops support for Node 6.