### PR TITLE
Work around enable debugging and logging

### DIFF
--- a/packages/electron/src/TestRunner.js
+++ b/packages/electron/src/TestRunner.js
@@ -45,7 +45,12 @@ const startWorker = async ({
       );
       const currentNodeBinPath = process.execPath;
       const electronBin = getElectronBin(rootDir);
-      return spawn(currentNodeBinPath, [electronBin, injectedCodePath], {
+      return spawn(currentNodeBinPath,
+        [
+          electronBin,
+          process.env.JEST_ELECTRON_RUNNER_DEBUG_PORT ? `--inspect=${process.env.JEST_ELECTRON_RUNNER_DEBUG_PORT}` : ''
+          injectedCodePath
+        ], {
         stdio: [
           'inherit',
           // redirect child process' stdout to parent process stderr, so it
@@ -59,7 +64,7 @@ const startWorker = async ({
           ...(isMain(target) ? {isMain: 'true'} : {}),
           JEST_SERVER_ID: serverID,
         },
-        detached: true,
+        detached: process.env.JEST_ELECTRON_DISABLE_PROCESS_DETACHMENT ? false : true,
       });
     },
   });


### PR DESCRIPTION
I'm not sure if this is a permanent solution (as I'm not sure what function `detach:true` was serving) but this enables people to easily get logs and attach a debugger to the test process which fixes https://github.com/facebook-atom/jest-electron-runner/issues/30

My rough vscode launch config below (was altered to remove a bunch of implementation specific details, so might not work if you copy exactly, but point is you use a compound launch task to 1. start the test and 2. connect to the process running the test at JEST_ELECTRON_RUNNER_DEBUG_PORT

	{
		"version": "0.2.0",
		"compounds": [
			{
				"name": "Electron - Run test file",
				"configurations": ["Run test file", "Connect to electron main"]
			}
		],
		"configurations": [
			{
				"name": "Run tests",
				"type": "node",
				"request": "launch",
				"env": {
					"JEST_ELECTRON_RUNNER_DEBUG_PORT": "8500"
				},
				"program": "node_modules/jest/bin/jest.js",
				"args": [
					"${command:currentDistFile}",
					"--runInBand",
				],
				"console": "integratedTerminal",
			},
			{
				"name": "Connect to electron main",
				"type": "node",
				"request": "attach",
				"port": 8500,
				"address": "localhost",
				"timeout": 30000,
				"restart":true
			},
		]
	}