### PR TITLE
Work around enable debugging and logging #59

### DIFF
--- a/packages/electron/src/TestRunner.js
+++ b/packages/electron/src/TestRunner.js
@@ -43,9 +43,19 @@ const startWorker = async ({
       const injectedCodePath = require.resolve(
         './electron_process_injected_code.js',
       );
+
       const currentNodeBinPath = process.execPath;
-      const electronBin = getElectronBin(rootDir);
-      return spawn(currentNodeBinPath, [electronBin, injectedCodePath], {
+			const electronBin = (0, _get_electron_bin.getElectronBin)(rootDir);
+			const spawnArgs = [electronBin]
+			if (process.env.JEST_ELECTRON_RUNNER_MAIN_THREAD_DEBUG_PORT) {
+				spawnArgs.push(`--inspect=${process.env.JEST_ELECTRON_RUNNER_MAIN_THREAD_DEBUG_PORT}`)
+			}
+			if (process.env.JEST_ELECTRON_RUNNER_RENDERER_THREAD_DEBUG_PORT) {
+				spawnArgs.push(`--remote-debugging-port=${process.env.JEST_ELECTRON_RUNNER_RENDERER_THREAD_DEBUG_PORT}`)
+			}
+			spawnArgs.push(injectedCodePath)
+
+      return spawn(currentNodeBinPath, spawnArgs, {
         stdio: [
           'inherit',
           // redirect child process' stdout to parent process stderr, so it
@@ -59,7 +69,7 @@ const startWorker = async ({
           ...(isMain(target) ? {isMain: 'true'} : {}),
           JEST_SERVER_ID: serverID,
         },
-        detached: true,
+        detached: process.env.JEST_ELECTRON_RUNNER_DISABLE_PROCESS_DETACHMENT ? false : true,
       });
     },
   });

--- a/packages/electron/src/TestRunner.js
+++ b/packages/electron/src/TestRunner.js
@@ -45,7 +45,7 @@ const startWorker = async ({
       );
 
       const currentNodeBinPath = process.execPath;
-			const electronBin = (0, _get_electron_bin.getElectronBin)(rootDir);
+      const electronBin = getElectronBin(rootDir);
 			const spawnArgs = [electronBin]
 			if (process.env.JEST_ELECTRON_RUNNER_MAIN_THREAD_DEBUG_PORT) {
 				spawnArgs.push(`--inspect=${process.env.JEST_ELECTRON_RUNNER_MAIN_THREAD_DEBUG_PORT}`)


### PR DESCRIPTION
I'm not sure if this is a permanent solution (as I'm not sure what function detach:true was serving) but this enables people to easily get logs and attach a debugger to the test process which fixes #30

My rough vscode launch config below (was altered to remove a bunch of implementation specific details, so might not work if you copy exactly, but point is you use a compound launch task to 1. start the test and 2. connect to the process running the test at JEST_ELECTRON_RUNNER_DEBUG_PORT

```
{
	"version": "0.2.0",
	"compounds": [
		{
			"name": "Electron - Run test file",
			"configurations": ["Run test file", "Connect to electron main"]
		}
	],
	"configurations": [
		{
			"name": "Run tests",
			"type": "node",
			"request": "launch",
			"env": {
				"JEST_ELECTRON_RUNNER_DEBUG_PORT": "8500"
			},
			"program": "node_modules/jest/bin/jest.js",
			"args": [
				"${command:currentDistFile}",
				"--runInBand",
			],
			"console": "integratedTerminal",
		},
		{
			"name": "Connect to electron main",
			"type": "node",
			"request": "attach",
			"port": 8500,
			"address": "localhost",
			"timeout": 30000,
			"restart":true
		},
	]
}
```