### PR TITLE
feat: support --no-sandbox flag

### DIFF
--- a/packages/electron/src/TestRunner.js
+++ b/packages/electron/src/TestRunner.js
@@ -47,6 +47,9 @@ const startWorker = async ({
       const currentNodeBinPath = process.execPath;
       const electronBin = getElectronBin(rootDir);
 			const spawnArgs = [electronBin]
+			if (process.env.JEST_ELECTRON_RUNNER_DISABLE_SANDBOX) {
+				spawnArgs.push('--no-sandbox');
+			}
 			if (process.env.JEST_ELECTRON_RUNNER_MAIN_THREAD_DEBUG_PORT) {
 				spawnArgs.push(`--inspect=${process.env.JEST_ELECTRON_RUNNER_MAIN_THREAD_DEBUG_PORT}`)
 			}


### PR DESCRIPTION
This will help support `jest-electron-runner` usage on container-based test infrastructure.

_EDIT:_ it turns out electron supports a little-known `ELECTRON_DISABLE_SANDBOX` flag, so this patch might be unnecessary (but we might want to document that flag better).

See also #51.