### PR TITLE
Keep a loaded BrowserWindow in memory

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://github.com/facebook-atom/jest-electron-runner",
     "repository": "https://github.com/facebook-atom/jest-electron-runner",
     "dependencies": {
-        "jest-message-util": "^24.0.0",
+        "jest-message-util": "^26.6.0",
         "node-ipc": "^9.1.1"
     }
 }

--- a/packages/core/types.js
+++ b/packages/core/types.js
@@ -21,7 +21,7 @@ export type ProjectConfig = {
   name: string,
   rootDir: string,
   setupFiles: Array<string>,
-  setupTestFrameworkScriptFile: ?string,
+  setupFilesAfterEnv: ?string,
 };
 export type Resolver = {};
 export type RawModuleMap = {};

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -9,11 +9,11 @@
     "dependencies": {
         "@jest-runner/core": "^3.0.0",
         "@jest-runner/rpc": "^3.0.0",
-        "jest-haste-map": "^25.0.0",
-        "jest-mock": "^25.0.0",
-        "jest-runner": "^25.0.0",
-        "jest-runtime": "^25.0.0",
-        "jest-util": "^25.0.0",
+        "jest-haste-map": "^26.6.0",
+        "jest-mock": "^26.6.0",
+        "jest-runner": "^26.6.0",
+        "jest-runtime": "^26.6.0",
+        "jest-util": "^26.6.0",
         "throat": "^4.1.0"
     },
     "peerDependencies": {

--- a/packages/electron/src/rpc/JestWorkerRPC.js
+++ b/packages/electron/src/rpc/JestWorkerRPC.js
@@ -104,7 +104,8 @@ module.exports = {
   runTest(testData: IPCTestData): Promise<TestResult> {
     return _runTest(testData);
   },
-  shutDown(): void {
-    return _destroyBrowserWindow();
+  shutDown(): Promise<any> {
+    _destroyBrowserWindow();
+    return Promise.resolve();
   },
 };

--- a/packages/nuclide-e2e/package.json
+++ b/packages/nuclide-e2e/package.json
@@ -10,8 +10,8 @@
         "@jest-runner/core": "^3.0.0",
         "@jest-runner/rpc": "^3.0.0",
         "fs-extra": "^7.0.0",
-        "jest-circus": "^24.0.0",
-        "jest-util": "^24.0.0",
+        "jest-circus": "^26.6.0",
+        "jest-util": "^26.6.0",
         "throat": "^4.1.0",
         "uuid": "^3.3.2"
     },

--- a/packages/nuclide-e2e/src/rpc/NuclideE2ERPC.js
+++ b/packages/nuclide-e2e/src/rpc/NuclideE2ERPC.js
@@ -61,9 +61,9 @@ module.exports = {
         testPath: testData.path,
       });
 
-      const {setupTestFrameworkScriptFile} = testData.config;
-      if (setupTestFrameworkScriptFile) {
-        require(setupTestFrameworkScriptFile);
+      const {setupFilesAfterEnv} = testData.config;
+      if (setupFilesAfterEnv) {
+        require(setupFilesAfterEnv);
       }
       require(testData.path);
       const testResult = await runAndTransformResultsToJestFormat({


### PR DESCRIPTION
It takes roughly 400-600ms for the `BrowserWindow` to load the url before running the test.
With this change, we keep a loaded window in memory for the next test, saving us the setup time.

In our case we have ~250 test suites, this saves us 2 minutes in CI.

The preloaded `BrowserWindow` is destroyed on cleanup.