### PR TITLE
Re-enable electron.remote

### DIFF
--- a/packages/electron/src/rpc/JestWorkerRPC.js
+++ b/packages/electron/src/rpc/JestWorkerRPC.js
@@ -46,7 +46,10 @@ const _runInBrowserWindow = (testData: IPCTestData): Promise<TestResult> => {
     const workerID = makeUniqWorkerId();
     const win = new BrowserWindow({
       show: false,
-      webPreferences: {nodeIntegration: true},
+      webPreferences: {
+        nodeIntegration: true,
+        enableRemoteModule: true
+      }
     });
 
     win.loadURL(`file://${require.resolve('../index.html')}`);


### PR DESCRIPTION
electron disabled access to electron.remote by default but it's rather convenient for tests, e.g.:

```js
const image = await electron.remote.getCurrentWindow().capturePage();
image.toPNG();
```