### PR TITLE
Add support noAsar through process.env

### DIFF
--- a/packages/electron/src/electron_process_injected_code.js
+++ b/packages/electron/src/electron_process_injected_code.js
@@ -18,7 +18,7 @@ import RPCConnection from '@jest-runner/rpc/RPCConnection';
 import JestWorkerRPC from './rpc/JestWorkerRPC';
 
 const isMain = process.env.isMain === 'true';
-
+process.noAsar = process.env.noAsar
 // for testing purposes, it is probably a good idea to keep everything at
 // the same scale so that renders do not vary from device to device.
 app.commandLine.appendSwitch('high-dpi-support', 1);


### PR DESCRIPTION
To disable ASAR support, we have to set ```process.Asar = true```, but it doesn't pass through spawning child process, when running the tests. so the electron that was spawned by the runner doesn't know that we set no ASAR support.

To fix it, I would like to use process.env.noAsar to pass through process.noAsar when spawn child process