### PR TITLE
Expose garbage collector to Electron when it was exposed in Node

### DIFF
--- a/packages/electron/src/TestRunner.js
+++ b/packages/electron/src/TestRunner.js
@@ -55,6 +55,9 @@ const startWorker = async ({
 			}
 			spawnArgs.push(injectedCodePath)
 
+      if (global.gc) {
+        spawnArgs.push("--js-flags=--expose-gc");
+      }
       return spawn(currentNodeBinPath, spawnArgs, {
         stdio: [
           'inherit',


### PR DESCRIPTION
Thanks to the new WeakRef feature it is possible to test for memory leaks when exposing the garbage collector to Node. With this pull request the garbage collector is also exposed to Electron when it was exposed to Node so the same tests which works with Node runner can also work with electron runner.

This is a very small change, it doesn't change any behavior except exposing the garbage collector to Electron and even this is only done when the user already exposed the garbage collector to Node. So for the standard usage this small change doesn't do anything. And for those who expose the garbage collector to Node this change is very useful for writing unit tests running in Electron which can check for memory leaks.