### PR TITLE
Stub Electron environment's useRealTimers function

### DIFF
--- a/packages/electron/src/Environment.js
+++ b/packages/electron/src/Environment.js
@@ -25,6 +25,7 @@ export default class ElectronEnvironment {
       useFakeTimers() {
         throw new Error('fakeTimers are not supproted in electron environment');
       },
+      useRealTimers() {},
       clearAllTimers() {},
     };
     installCommonGlobals(global, config.globals);


### PR DESCRIPTION
This adds a stub `useRealTimers` function to the Electron environment provided to Jest. Since fake timers aren't supported, there's nothing that has to happen here. By adding this stub, errors like https://github.com/testing-library/dom-testing-library/issues/905 can be avoided.